### PR TITLE
add product filtering support for title param

### DIFF
--- a/backend/app/controllers/items_controller.rb
+++ b/backend/app/controllers/items_controller.rb
@@ -7,6 +7,7 @@ class ItemsController < ApplicationController
 
   def index
     @items = Item.includes(:tags)
+    @items = @items.where("title LIKE ?", "%#{params[:title]}%")
 
     @items = @items.tagged_with(params[:tag]) if params[:tag].present?
     @items = @items.sellered_by(params[:seller]) if params[:seller].present?


### PR DESCRIPTION
# Description
Add product filtering support to our API.
In other words, when retrieving a list of items using a GET request, there can be an option to add a query parameter called “title”, so that once we call this endpoint, the backend will show all the relevant items whose title contains the same title query.